### PR TITLE
Feature/transform results

### DIFF
--- a/MeteorGriddle.jsx
+++ b/MeteorGriddle.jsx
@@ -16,7 +16,7 @@ MeteorGriddle = React.createClass({
     matchingResultsCount: React.PropTypes.string, // the name of the matching results counter
     filteredFields: React.PropTypes.array, // an array of fields to search through when filtering
     subsManager: React.PropTypes.object,
-    transformResults: React.PropTypes.function,
+    transformResult: React.PropTypes.func, // a function to transform one entry in the list
     // plus regular Griddle props
   },
 
@@ -27,7 +27,7 @@ MeteorGriddle = React.createClass({
       useExternal: false,
       externalFilterDebounceWait: 300,
       externalResultsPerPage: 10,
-      transformResults: (results) => results
+      transformResult: (entry) => entry // identity
     };
   },
 
@@ -89,9 +89,9 @@ MeteorGriddle = React.createClass({
       );
     }
 
-    const results = this.transformResults(
-        this.props.collection.find(this.state.query, options).fetch()
-      );
+    const results =
+      this.props.collection.find(this.state.query, options).map(this.props.transformResult);
+
 
     return {
       loading: !pubHandle.ready(),

--- a/MeteorGriddle.jsx
+++ b/MeteorGriddle.jsx
@@ -16,6 +16,7 @@ MeteorGriddle = React.createClass({
     matchingResultsCount: React.PropTypes.string, // the name of the matching results counter
     filteredFields: React.PropTypes.array, // an array of fields to search through when filtering
     subsManager: React.PropTypes.object,
+    transformResults: React.PropTypes.function,
     // plus regular Griddle props
   },
 
@@ -26,6 +27,7 @@ MeteorGriddle = React.createClass({
       useExternal: false,
       externalFilterDebounceWait: 300,
       externalResultsPerPage: 10,
+      transformResults: (results) => results
     };
   },
 
@@ -87,8 +89,9 @@ MeteorGriddle = React.createClass({
       );
     }
 
-    const results =
-      this.props.collection.find(this.state.query, options).fetch();
+    const results = this.transformResults(
+        this.props.collection.find(this.state.query, options).fetch()
+      );
 
     return {
       loading: !pubHandle.ready(),


### PR DESCRIPTION
This MR allows to specify a `transformResult` function. This will invoked for every document in the list (on the collection-cursor).

Background:

Currently, showing nested properties in the table seems to be broken in griddle. With this change, we are able to flat the entries and use the path to the property:

```

import flat from 'flat'; // https://www.npmjs.com/package/flat
//....

  <MeteorGriddle
        transformResult={flat}
        columns={['_id', 'emails.0.address', 'profile.firstname', 'profile.lastname']}
        publication={"users.admin.list"}
        collection={Meteor.users}
        matchingResultsCount={"users.admin.count"}
      />


```
